### PR TITLE
Bug 976223 - Service-related data persistence layer.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: node_js
 node_js:
   - "0.10"
 
+services: mongodb
+
 notifications:
   irc:
     channels:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ jshint:
 .PHONY: mocha
 mocha:
 	@env NODE_ENV=test SESSION_SECRET=${SESSION_SECRET} \
-		./node_modules/mocha/bin/mocha --reporter spec
+		./node_modules/mocha/bin/mocha test/* --reporter spec
 
 .PHONY: runserver
 runserver:

--- a/loop/stores/memory.js
+++ b/loop/stores/memory.js
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Simple in-memory key/value store. This is provided as an example
+ * implementation: it operates in O(n) time and is consequently not really
+ * usable for anything other than small data sets.
+ *
+ * Available options:
+ *
+ * - {Array} unique: list of fields which compound value should be unique.
+ *
+ * @param  {Object} options          Options object
+ * @return {MemoryStore}
+ */
+module.exports = function MemoryStore(options) {
+  var _db = [],
+      _options = options || {unique: []};
+
+  /**
+   * Checks if a record is a duplicate if unique constraints have been defined.
+   * Sends back a boolean accordingly.
+   *
+   * @param  {Object}   record Record object
+   * @param  {Function} cb     Callback(err, bool)
+   */
+  function _checkDuplicate(record, cb) {
+    if (!Array.isArray(_options.unique) || _options.unique.length === 0) {
+      cb(null, false);
+      return;
+    }
+    var query = _options.unique.reduce(function(queryObj, field) {
+      queryObj[field] = record[field];
+      return queryObj;
+    }, {});
+    this.findOne(query, function(err, record) {
+      if (err) {
+        cb(err);
+        return;
+      }
+      cb(null, !!record);
+    });
+  }
+
+  return {
+    /**
+     * Returns store name; in the case of a memory store this doesn't make sense
+     * so we always return null.
+     *
+     * @return {Null}
+     */
+    get name() {
+      return null;
+    },
+
+    /**
+     * Adds a record to the collection.
+     *
+     * @param {Object}   record Record Object
+     * @param {Function} cb     Callback(err, record)
+     */
+    add: function(record, cb) {
+      _db = _db || [];
+      _checkDuplicate.call(this, record, function(err, exists) {
+        if (err) {
+          cb(err);
+          return;
+        }
+        if (exists) {
+          cb(new Error("Cannot add a duplicate entry"));
+          return;
+        }
+        _db.push(record);
+        cb(null, record);
+      });
+    },
+
+    /**
+     * Retrieves multiple records matching all the criterias defined by the
+     * query object.
+     *
+     * @param  {Object}   query Query object
+     * @param  {Function} cb    Callback(err, records)
+     */
+    find: function(query, cb) {
+      _db = _db || [];
+      cb(null, _db.filter(function(record) {
+        return Object.keys(query).every(function(field) {
+          return record[field] === query[field];
+        });
+      }));
+    },
+
+    /**
+     * Retrieves a single record matching all the criterias defined by the
+     * query object. Sends undefined if no record was found.
+     *
+     * @param  {Object}   query Query object
+     * @param  {Function} cb    Callback(err, record|undefined)
+     */
+    findOne: function(query, cb) {
+      this.find(query, function(err, records) {
+        if (records.length === 0) {
+          cb(null, null);
+          return;
+        }
+        cb(null, records.shift());
+      });
+    },
+
+    /**
+     * Drops current database.
+     * @param  {Function} cb Callback(err)
+     */
+    drop: function(cb) {
+      _db = [];
+      cb(null);
+    }
+  };
+};

--- a/loop/stores/mongo.js
+++ b/loop/stores/mongo.js
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var MongoClient = require('mongodb').MongoClient;
+
+/**
+ * Simple MongoDB key/value store. Handles a single collection to store data.
+ *
+ * Available options:
+ *
+ * - {Array} unique: list of fields which compound value should be unique.
+ *
+ * @param  {String} connectionString MongoDB connection string
+ * @param  {String} name             Store name, used to name the collection
+ * @param  {Object} options          Options object
+ * @return {MongoStore}
+ */
+module.exports = function MongoStore(connectionString, name, options) {
+  "use strict";
+
+  var _db,
+      _options = options || {unique: []};
+
+  if (!connectionString) {
+    throw new Error("The connectionString argument is required");
+  }
+
+  if (!name) {
+    throw new Error("The name argument is required");
+  }
+
+  /**
+   * Ensures the database is connected, sends back an instance of the
+   * db. Creates defined unique index if any.
+   *
+   * @private
+   * @param  {Function} cb Callback(err, db)
+   */
+  function _ensureConnected(cb) {
+    if (_db) {
+      cb(null, _db);
+      return;
+    }
+    MongoClient.connect(connectionString, function(err, resultDb) {
+      if (err) {
+        cb(err);
+        return;
+      }
+      _db = resultDb;
+      if (!Array.isArray(_options.unique) || _options.unique.length === 0) {
+        cb(null, _db);
+        return;
+      }
+      var defs = _options.unique.reduce(function(obj, field) {
+        obj[field] = 1;
+        return obj;
+      }, {});
+      _db.collection(name).ensureIndex(defs, {unique: true}, function(err) {
+        if (err) {
+          cb(err);
+          return;
+        }
+        cb(null, _db);
+      });
+    });
+  }
+
+  return {
+    /**
+     * Returns current name value (read only).
+     *
+     * @return {String}
+     */
+    get name() {
+      return name;
+    },
+
+    /**
+     * Adds a single record to the collection.
+     *
+     * @param {Object}   record Record Object
+     * @param {Function} cb     Callback(err, record)
+     */
+    add: function(record, cb) {
+      _ensureConnected(function(err, db) {
+        if (err) {
+          cb(err);
+          return;
+        }
+        db.collection(name).insert(record, function(err, records) {
+          if (err) {
+            cb(err);
+            return;
+          }
+          cb(null, records[0]);
+        });
+      });
+    },
+
+    /**
+     * Retrieves multiple records matching the provided query object.
+     *
+     * @param  {Object}   query Query object
+     * @param  {Function} cb    Callback(err, record)
+     */
+    find: function(query, cb) {
+      _ensureConnected(function(err, db) {
+        if (err) {
+          cb(err);
+          return;
+        }
+        db.collection(name).find(query).toArray(cb);
+      });
+    },
+
+    /**
+     * Retrieves a single record matching the provided query object.
+     *
+     * @param  {Object}   query Query object
+     * @param  {Function} cb    Callback(err, record|null)
+     */
+    findOne: function(query, cb) {
+      _ensureConnected(function(err, db) {
+        if (err) {
+          cb(err);
+          return;
+        }
+        db.collection(name).findOne(query, cb);
+      });
+    },
+
+    /**
+     * Drops current collection.
+     * @param  {Function} cb Callback(err)
+     */
+    drop: function(cb) {
+      _ensureConnected(function(err, db) {
+        if (err) {
+          cb(err);
+          return;
+        }
+        try {
+          // drop() is a synchronous operation
+          db.collection(name).drop();
+          cb(null);
+        } catch (err) {
+          cb(err);
+        }
+      });
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "express": "3.x",
     "bunyan": "0.21.x",
-    "urlsafe-base64": "0.0.2"
+    "urlsafe-base64": "0.0.2",
+    "mongodb": "1.3.23"
   },
   "devDependencies": {
     "awsbox": "0.6.x",

--- a/test/stores_test.js
+++ b/test/stores_test.js
@@ -1,0 +1,223 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* global it, describe */
+
+var expect = require("chai").expect;
+
+var MongoStore = require("../loop/stores/mongo");
+var MemoryStore = require("../loop/stores/memory");
+
+describe("Stores", function() {
+  "use strict";
+
+  describe("MongoStore", function() {
+    describe("#constructor", function() {
+      it("should require a connection string argument", function() {
+        expect(function() {
+          new MongoStore();
+        }).Throw(Error, /connectionString/);
+      });
+
+      it("should require a name argument", function() {
+        expect(function() {
+          new MongoStore("foo");
+        }).Throw(Error, /name/);
+      });
+    });
+
+    describe("get name()", function() {
+      it("should expose a name property", function() {
+        var store = new MongoStore("foo", "bar");
+        expect(store.name).eql("bar");
+      });
+    });
+  });
+
+  describe("MemoryStore", function() {
+    describe("get name()", function() {
+      it("should expose a null name property", function() {
+        var store = new MemoryStore();
+        expect(store.name).to.be.a("null");
+      });
+    });
+  });
+
+  // both stores implements the same interface, so using the very same suite
+  // for both
+  function testStore(name, createStore) {
+    describe(name, function() {
+      var store;
+
+      afterEach(function(done) {
+        store.drop(function(err) {
+          store = undefined;
+          done(err);
+        });
+      });
+
+      describe("#add", function() {
+        describe("without unique checks enabled", function() {
+          beforeEach(function() {
+            store = createStore();
+          });
+
+          it("should add a record to a given collection", function(done) {
+            store.add({a: 1, b: 2}, function(err, record) {
+              expect(err).to.be.a("null");
+              expect(record).to.be.a("object");
+              expect(record.a).eql(1);
+              done();
+            });
+          });
+
+          it("should allow storing duplicates", function(done) {
+            store.add({a: 1, b: 2}, function(err, record) {
+              store.add({a: 1, b: 2}, function(err) {
+                expect(err).to.be.a("null");
+                done();
+              });
+            });
+          });
+        });
+
+        describe("with unique checks enabled, single field", function() {
+          beforeEach(function() {
+            store = createStore({unique: ["a"]});
+          });
+
+          it("shouldn't allow storing duplicates", function(done) {
+            store.add({a: 1, b: 2}, function(err) {
+              store.add({a: 1, b: 3}, function(err) {
+                expect(err).to.be.an.instanceOf(Error);
+                done();
+              });
+            });
+          });
+        });
+
+        describe("with unique checks enabled, multiple field", function() {
+          beforeEach(function() {
+            store = createStore({unique: ["a", "b"]});
+          });
+
+          it("shouldn't allow storing duplicates", function(done) {
+            store.add({a: 1, b: 2}, function(err) {
+              store.add({a: 1, b: 2}, function(err) {
+                expect(err).to.be.an.instanceOf(Error);
+                done();
+              });
+            });
+          });
+
+          it("shouldn't send an error on partial duplicate", function(done) {
+            store.add({a: 1, b: 2}, function(err) {
+              store.add({a: 1, b: 3}, function(err) {
+                expect(err).to.be.a("null");
+                done();
+              });
+            });
+          });
+        });
+      });
+
+      describe("#find", function() {
+        beforeEach(function() {
+          store = createStore();
+        });
+
+        it("should retrieve records out of a query object", function(done) {
+          store.add({a: 1, b: 2}, function() {
+            store.add({a: 1, b: 3}, function() {
+              store.find({a: 1}, function(err, records) {
+                expect(err).to.be.a("null");
+                expect(records).to.have.length.of(2);
+                done();
+              });
+            });
+          });
+        });
+
+        it("should retrieve records matching all passed criterias",
+          function(done) {
+            store.add({a: 1, b: 2, c: 42}, function() {
+              store.add({a: 1, b: 3, c: 42}, function() {
+                store.find({a: 1, c: 42}, function(err, records) {
+                  expect(err).to.be.a("null");
+                  expect(records).to.have.length.of(2);
+                  expect(records[0].b).eql(2);
+                  expect(records[1].b).eql(3);
+                  done();
+                });
+              });
+            });
+          });
+
+        it("should return an empty array on no match found", function(done) {
+          store.find({x: 42}, function(err, records) {
+            expect(err).to.be.a("null");
+            expect(records).to.be.a("array");
+            expect(records).to.have.length.of(0);
+            done();
+          });
+        });
+      });
+
+      describe("#findOne", function() {
+        beforeEach(function() {
+          store = createStore();
+        });
+
+        it("should retrieve a record out of a query object", function(done) {
+          store.add({a: 1, b: 2}, function(err) {
+            store.findOne({a: 1}, function(err, record) {
+              expect(err).to.be.a("null");
+              expect(record).to.be.a("object");
+              expect(record.a).eql(1);
+              done();
+            });
+          });
+        });
+
+        it("should return a null when no record is found", function(done) {
+          store.findOne({x: 42}, function(err, record) {
+            expect(err).to.be.a("null");
+            expect(record).to.be.a("null");
+            done();
+          });
+        });
+      });
+
+      describe("#drop", function() {
+        beforeEach(function() {
+          store = createStore();
+        });
+
+        it("should drop the database", function(done) {
+          store.add({a: 1}, function() {
+            store.drop(function(err) {
+              expect(err).to.be.a("null");
+              store.find({}, function(err, records) {
+                expect(err).to.be.a("null");
+                expect(records).to.have.length.of(0);
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+  }
+
+  describe("constructed", function() {
+    testStore("MongoStore", function createMongoStore(options) {
+      return new MongoStore(
+        "mongodb://127.0.0.1:27017/loop_test", "test_coll", options);
+    });
+
+    testStore("MemoryStore", function createMemoryStore(options) {
+      return new MemoryStore(options);
+    });
+  });
+});


### PR DESCRIPTION
Bugzilla bug [#976223](https://bugzilla.mozilla.org/show_bug.cgi?id=976223)

This patch implements two distinct persistence layers sharing the very same API for storing services-related data:
- `MongoStore` using MongoDB as a backend
- `MemoryStore` storing data in-memory
