### PR TITLE
[Tokenlib] gives options to TokenManager for more parametrization

### DIFF
--- a/loop/tokenlib.js
+++ b/loop/tokenlib.js
@@ -3,12 +3,14 @@
 var crypto = require("crypto");
 var base64 = require('urlsafe-base64');
 
-function TokenManager(secret) {
+function TokenManager(secret, options) {
   if (!secret)
     throw new Error("TokenManager requires a 'secret' argument");
+  options = options || {};
 
   this.secret = secret;
-  this.signatureSize = 32 / 8;
+  this.signatureSize = options.signatureSize || 32 / 8;
+  this.digestAlgorithm = options.digestAlgorithm || "sha256";
 }
 
 TokenManager.prototype = {
@@ -17,12 +19,12 @@ TokenManager.prototype = {
 
     payload = new Buffer(JSON.stringify(data));
 
-    hmac = crypto.createHmac("sha256", this.secret);
+    hmac = crypto.createHmac(this.digestAlgorithm, this.secret);
     hmac.write(payload);
     hmac.end();
 
     signature = hmac.read();
-    // keep the last 32 bits only, so we avoid huge signatures
+    // keep the last `signatureSize` bytes only, so we avoid huge signatures
     signature = signature.slice(signature.length - this.signatureSize);
 
     return base64.encode(Buffer.concat([payload,signature]));
@@ -30,16 +32,16 @@ TokenManager.prototype = {
 
   decode: function(token) {
     token = base64.decode(token);
-    // Split token into <payload><signature: 32 bits>
+    // Split token into <payload><signature: signatureSize bytes>
     var signature = token.slice(token.length - this.signatureSize).toString();
     var payload = token.slice(0, token.length - this.signatureSize).toString();
 
-    var hmac = crypto.createHmac("sha256", this.secret);
+    var hmac = crypto.createHmac(this.digestAlgorithm, this.secret);
     hmac.write(payload);
     hmac.end();
 
     var payloadSignature = hmac.read();
-    // The signature is always the last 32 bits only
+    // The signature is the last `signatureSize` bits only
     payloadSignature = payloadSignature
       .slice(payloadSignature.length - this.signatureSize).toString();
 


### PR DESCRIPTION
Now accepts options with `signatureSize` and `digestAlgorithm`.

This PR addresses @ekr comments on https://github.com/mozilla/loop-server/commit/193162ef5ab4f08994128adf72ea96b31bfe39bb#commitcomment-5473517
