### PR TITLE
Bug 971995 Server extracts and validate info from call URI

### DIFF
--- a/test/functional_test.js
+++ b/test/functional_test.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var expect = require("chai").expect;
+var sinon  = require("sinon");
 var request = require("supertest");
 var sinon = require("sinon");
 
@@ -14,6 +15,8 @@ var auth = require("../loop/authentication");
 
 describe("HTTP API exposed by the server", function() {
   "use strict";
+
+  var now = 1393595554796;
 
   describe("POST /call-url", function() {
     var jsonReq, sandbox, expectedAssertion;
@@ -88,6 +91,7 @@ describe("HTTP API exposed by the server", function() {
       });
 
       it("should generate a valid call-url", function(done) {
+        var clock = sinon.useFakeTimers(now);
         var tokenManager = new tokenlib.TokenManager(conf.get('tokenSecret'));
 
         jsonReq
@@ -102,8 +106,11 @@ describe("HTTP API exposed by the server", function() {
             // XXX: the content of the token should change in the
             // future.
             token = callUrl.split("/").pop();
-            expect(tokenManager.decode(token)).to.deep.equal({});
+            expect(tokenManager.decode(token)).to.deep.equal({
+              expires: now + tokenManager.timeout
+            });
 
+            clock.restore();
             done(err);
           });
       });
@@ -134,6 +141,13 @@ describe("HTTP API exposed by the server", function() {
           .expect(401)
           .end(done);
       });
+    });
+
+    it.skip("should attach a session to the user agent", function() {
+    });
+
+    it.skip("should store push url", function() {
+      // XXX move in a different location.
     });
   });
 

--- a/test/tokenlib_test.js
+++ b/test/tokenlib_test.js
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+var crypto = require("crypto");
 var expect = require("chai").expect;
+var sinon  = require("sinon");
 var base64 = require('urlsafe-base64');
 var tokenlib = require("../loop/tokenlib");
 
@@ -11,7 +13,20 @@ describe("TokenManager", function() {
   "use strict";
 
   var SECRET = "this is not a secret";
-  var tokenManager = new tokenlib.TokenManager(SECRET);
+  var now = 1393595554796;
+  var sandbox, clock, tokenManager;
+
+  beforeEach(function() {
+    sandbox = sinon.sandbox.create();
+    clock = sinon.useFakeTimers(now);
+
+    tokenManager = new tokenlib.TokenManager(SECRET);
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+    clock.restore();
+  });
 
   describe("constructor", function() {
 
@@ -23,6 +38,16 @@ describe("TokenManager", function() {
       expect(failure).to.Throw(/TokenManager requires a 'secret' argument/);
     });
 
+    it("should change the default timeout if provided", function() {
+      var timeout = 10000; // 10 seconds
+      var tokenManager = new tokenlib.TokenManager(SECRET, {timeout: timeout});
+      var token = tokenManager.encode({some: "data"});
+
+      expect(tokenManager.decode(token)).to.deep.equal({
+        some: "data",
+        expires: now + timeout
+      });
+    });
   });
 
   describe("#encode", function() {
@@ -35,16 +60,58 @@ describe("TokenManager", function() {
       var token = tokenManager.encode({some: "data"});
       expect(base64.validate(token)).to.equal(true);
     });
+
+    it("should parametrize the size of the token according to a given " +
+      "signatureSize parameter", function() {
+        var token1 = tokenManager.encode({some: "data"});
+        var token2 = (new tokenlib.TokenManager("a secret", {
+          signatureSize: 128/8
+        })).encode({some: "data"});
+        expect(token1.length < token2.length).to.equal(true);
+      });
+
+    it("should use the given digest algorithm", function() {
+      sandbox.spy(crypto, "createHmac");
+      (new tokenlib.TokenManager("a secret", {
+        digestAlgorithm: "sha1"
+      })).encode({some: "data"});
+
+      sinon.assert.calledOnce(crypto.createHmac);
+      sinon.assert.calledWith(crypto.createHmac, "sha1");
+    });
+
+    it("should add a default `expires` time", function() {
+      var token = tokenManager.encode({some: "data"});
+
+      expect(tokenManager.decode(token)).to.deep.equal({
+        some: "data",
+        expires: now + tokenManager.timeout
+      });
+    });
+
+    it("should accept a given `expires` time", function() {
+      var expires = now + 10000; // now + 10 seconds
+      var token = tokenManager.encode({some: "data", expires: expires});
+
+      expect(tokenManager.decode(token)).to.deep.equal({
+        some: "data",
+        expires: expires
+      });
+    });
   });
 
   describe("#decode", function() {
     it("should decode a valid encoded token", function() {
       var data = {some: "data"};
       var token = tokenManager.encode(data);
+
+      // XXX: here, the decoded data carries more than just the `some`
+      // property but also as an `expires` property. Despite this
+      // fact, deep equality seems to not bother and do not fail.
       expect(tokenManager.decode(token)).to.deep.equal(data);
     });
 
-    it("should trhow an error if the signature is invalid", function() {
+    it("should throw an error if the signature is invalid", function() {
       var data = {some: "data"};
       var tokenForger = new tokenlib.TokenManager("h4x0r");
       var token = tokenForger.encode(data);
@@ -52,6 +119,17 @@ describe("TokenManager", function() {
         tokenManager.decode(token);
       };
       expect(failure).to.Throw(/Invalid signature/);
+    });
+
+    it("should throw an error if the token expired", function() {
+      var expires = Date.now() - 10000; // now - 10 seconds
+      var data = {some: "data", expires: expires};
+      var token = tokenManager.encode(data);
+      var failure = function() {
+        tokenManager.decode(token);
+      };
+
+      expect(failure).to.Throw(/The token expired/);
     });
   });
 


### PR DESCRIPTION
Implement a `tokenlib` module to extract and validate information encoded in call-me temporary URI.

See [Bug 971995](https://bugzilla.mozilla.org/show_bug.cgi?id=971995) for more information.
