### PR TITLE
Bug 978454: Added code coverage report to test output.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+coverage
+html-report
+lib-cov

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 NODE_LOCAL_BIN=./node_modules/.bin
 
 .PHONY: test
-test: lint mocha
+test: lint cover-mocha
 
 install:
 	@npm install
@@ -14,7 +14,12 @@ install:
 lint: jshint
 
 clean:
-	rm -rf .venv node_modules
+	rm -rf .venv node_modules coverage lib-cov html-report
+
+.PHONY: cover-mocha
+cover-mocha:
+	@env $(NODE_LOCAL_BIN)/istanbul cover $(NODE_LOCAL_BIN)/_mocha -- --reporter spec test/*
+	@echo aim your browser at coverage/lcov-report/index.html for details
 
 .PHONY: jshint
 jshint:


### PR DESCRIPTION
Bug [978454](https://bugzilla.mozilla.org/show_bug.cgi?id=978454)

This patch adds support for code coverage reporting to the `test` command using `istanbul`:

![screen shot 2014-03-01 at 11 51 05](https://f.cloud.github.com/assets/41547/2301400/38ca9aea-a141-11e3-9921-f4afa634dd82.png)

It also generates a browsable HTML report, stored in `coverage/lcov-report/index.html`:

![screen shot 2014-03-01 at 12 25 15](https://f.cloud.github.com/assets/41547/2301401/38cd7a44-a141-11e3-9784-9bacd2cefa2a.png)

Note: this PR doesn't address any detected lack of code coverage in the current codebase.
