### PR TITLE
Bug 986363 — Rename token to sessionToken in both GET /calls and POST /calls/:token

### DIFF
--- a/loop/index.js
+++ b/loop/index.js
@@ -184,7 +184,7 @@ app.get("/calls", sessions.requireSession, sessions.attachSession,
           return {
             apiKey: tokBox.apiKey,
             sessionId: record.sessionId,
-            token: record.calleeToken
+            sessionToken: record.calleeToken
           };
         });
 
@@ -242,7 +242,7 @@ app.post('/calls/:token', validateToken, requireParams("nickname"),
           res.set("Access-Control-Allow-Methods", "GET,POST");
           res.json(200, {
             sessionId: tokboxInfo.sessionId,
-            token: tokboxInfo.callerToken,
+            sessionToken: tokboxInfo.callerToken,
             apiKey: tokBox.apiKey
           });
         });

--- a/test/functional_test.js
+++ b/test/functional_test.js
@@ -390,7 +390,7 @@ describe("HTTP API exposed by the server", function() {
         return {
           apiKey: tokBoxConfig.apiKey,
           sessionId: call.sessionId,
-          token: call.calleeToken
+          sessionToken: call.calleeToken
         };
       });
 
@@ -404,7 +404,7 @@ describe("HTTP API exposed by the server", function() {
       var callsList = [{
         apiKey: tokBoxConfig.apiKey,
         sessionId: calls[2].sessionId,
-        token: calls[2].calleeToken
+        sessionToken: calls[2].calleeToken
       }];
 
       req.send({version: 2}).expect(200).end(function(err, res) {
@@ -548,7 +548,7 @@ describe("HTTP API exposed by the server", function() {
             }
             expect(res.body).eql({
               sessionId: tokBoxSessionId,
-              token: tokBoxCallerToken,
+              sessionToken: tokBoxCallerToken,
               apiKey: tokBox.apiKey
             });
             done();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=986363
