### PR TITLE
Changing bug URL from GitHub issues to Bugzilla

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.3.0-dev",
   "author": "Mozilla (https://mozilla.org/)",
   "homepage": "https://github.com/mozilla-services/loop-server/",
-  "bugs": "https://github.com/mozilla-services/loop-server/issues/",
+  "bugs": "https://bugzilla.mozilla.org/enter_bug.cgi?product=Loop&component=Server",
   "repository": {
     "type": "git",
     "url": "git@github.com:mozilla-services/loop-server.git"


### PR DESCRIPTION
Setting bug URL to https://bugzilla.mozilla.org/enter_bug.cgi?product=Loop&component=Server
