### PR TITLE
Bug 1000782 - Adds Access-Control-Expose-Headers

### DIFF
--- a/loop/index.js
+++ b/loop/index.js
@@ -231,6 +231,7 @@ app.post('/registration', attachOrCreateHawkSession,
           res.json(503, "Service Unavailable");
           return;
         }
+        res.setHeader('Access-Control-Expose-Headers', 'Hawk-Session-Token');
         res.json(200, "ok");
       });
   });


### PR DESCRIPTION
This header lets a server whitelist headers that browsers are allowed to access. Without it the FxOS Loop client cannot access the 'Hawk-Session-Token' header.

@ametaireau could you have a look please?
