### PR TITLE
Fix 1019504 — Update session expires on auth.

### DIFF
--- a/loop/index.js
+++ b/loop/index.js
@@ -76,6 +76,7 @@ function hmac(payload, secret, algorithm) {
 
 function setUser(req, res, tokenId, done) {
   storage.getHawkUser(tokenId, function(err, user) {
+    storage.touchHawkSession(tokenId);
     // If an identity is defined for this hawk session, use it.
     if (user !== null) {
       req.user = user;
@@ -153,7 +154,6 @@ function authenticate(req, res, next) {
   if (authorization !== undefined) {
     var splitted = authorization.split(" ");
     var policy = splitted[0];
-    // var assertion = splitted[1];
 
     // Next, let's check which one the user wants to use.
     if (supported.map(function(s) { return s.toLowerCase(); })

--- a/loop/storage/redis.js
+++ b/loop/storage/redis.js
@@ -131,6 +131,14 @@ RedisStorage.prototype = {
     );
   },
 
+  touchHawkSession: function(tokenId, callback) {
+    this._client.expire(
+      'hawk.' + tokenId,
+      this._settings.hawkSessionDuration,
+      callback
+    );
+  },
+
   getHawkSession: function(tokenId, callback) {
     this._client.get('hawk.' + tokenId, function(err, result) {
       if (err) {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -9,6 +9,7 @@ var crypto = require("crypto");
 var addHawk = require("superagent-hawk");
 var supertest = addHawk(require("supertest"));
 var sinon = require("sinon");
+var assert = sinon.assert;
 var tokenlib = require("../loop/tokenlib");
 var fxaAuth = require("../loop/fxa");
 var Token = require("../loop/token").Token;
@@ -260,6 +261,21 @@ describe("index.js", function() {
               done();
             });
         });
+      it("should update session expiration time on auth", function(done) {
+        sandbox.spy(storage, "touchHawkSession");
+        supertest(app)
+          .post("/with-authenticate")
+          .hawk(hawkCredentials)
+          .expect(200)
+          .end(function(err) {
+            if (err) {
+              throw err;
+            }
+            assert.calledWithExactly(storage.touchHawkSession,
+                                     hawkCredentials.id);
+            done();
+          });
+      });
     });
 
     it("should generate new hawk sessions if no authentication is provided",


### PR DESCRIPTION
When someone authenticates with an existing hawk session, touch the expiration
time so that it continues to be valid.

https://bugzilla.mozilla.org/show_bug.cgi?id=1019504
