### PR TITLE
FakeTokBox should expose an apiKey property.

### DIFF
--- a/loop/tokbox.js
+++ b/loop/tokbox.js
@@ -50,6 +50,7 @@ TokBox.prototype = {
 function FakeTokBox(serverURL) {
   this._counter = 0;
   this.serverURL = conf.get("fakeTokBoxURL");
+  this.apiKey = "falseApiKey";
 }
 
 FakeTokBox.prototype = {

--- a/test/tokbox_test.js
+++ b/test/tokbox_test.js
@@ -131,6 +131,9 @@ describe("FakeTokBox", function() {
       sandbox.restore();
     });
 
+    it("should expose a apiKey property.", function() {
+      expect(tokbox.apiKey).eql('falseApiKey');
+    });
 
     it("should return new session and tokens.", function(done) {
       tokbox.getSessionTokens(function(err, credentials) {


### PR DESCRIPTION
Otherwise, the returned JSON objects from the server doesn't contain the apiKey
information, since its value is set to "undefined".
