### PR TITLE
Bug 1035980 — Add callToken information as well as callUrl to avoid parsing

### DIFF
--- a/loop/index.js
+++ b/loop/index.js
@@ -483,6 +483,7 @@ app.post('/call-url', requireHawkSession, requireParams('callerId'),
         // XXX Bug 1032966 - call_url is deprecated
         res.json(200, {
           callUrl: conf.get("webAppUrl").replace("{token}", req.token),
+          callToken: req.token,
           call_url: conf.get("webAppUrl").replace("{token}", req.token),
           expiresAt: req.urlData.expires
         });
@@ -543,6 +544,7 @@ app.get('/calls', requireHawkSession, function(req, res) {
           sessionToken: record.calleeToken,
           callUrl: conf.get("webAppUrl").replace("{token}", record.callToken),
           call_url: conf.get("webAppUrl").replace("{token}", record.callToken),
+          callToken: record.callToken,
           urlCreationDate: record.urlCreationDate,
           progressURL: progressURL
         };

--- a/test/functional_test.js
+++ b/test/functional_test.js
@@ -845,6 +845,7 @@ describe("HTTP API exposed by the server", function() {
               callUrl: conf.get('webAppUrl').replace('{token}', call.callToken),
               call_url: conf.get('webAppUrl')
                 .replace('{token}', call.callToken),
+              callToken: call.callToken,
               urlCreationDate: call.urlCreationDate,
               progressURL: progressURL
             };
@@ -871,6 +872,7 @@ describe("HTTP API exposed by the server", function() {
           callUrl: conf.get('webAppUrl').replace('{token}', calls[2].callToken),
           call_url: conf.get('webAppUrl')
             .replace('{token}', calls[2].callToken),
+          callToken: calls[2].callToken,
           urlCreationDate: calls[2].urlCreationDate,
           progressURL: progressURL
         }];


### PR DESCRIPTION
the url to get the token.

https://bugzilla.mozilla.org/show_bug.cgi?id=1035980
