### PR TITLE
Linting the files in loop/storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ cover-mocha:
 
 .PHONY: jshint
 jshint:
-	@$(NODE_LOCAL_BIN)/jshint test loop/*.js
+	@$(NODE_LOCAL_BIN)/jshint test loop/{,**/}*.js
 
 .PHONY: mocha
 mocha:

--- a/config/sample.json
+++ b/config/sample.json
@@ -1,25 +1,29 @@
 {
   "host": "localhost",
-    "port": 5000,
-    "macSecret": "263ceaa5546dce837191be98db91e852ae8d050d6805a402272e0c776193cfba",
-    "encryptionSecret": "7c69b9ca88e4f127f7280368f7055646",
-    "userMacAlgorithm": "sha256",
-    "userMacSecret": "5a25ad4feadd45fdcbb05402658272da",
-    "sessionSecret": "this is not a secret",
-    "useSSL": false,
-    "tokBox": {
-      "credentials": {
-        "default": {
-          "apiKey": "<put your apiKey here>",
-          "apiSecret": "<put your apiSecret here>"
-        }
-      },
-      "tokenDuration": 86400
+  "port": 5000,
+  "macSecret": "263ceaa5546dce837191be98db91e852ae8d050d6805a402272e0c776193cfba",
+  "encryptionSecret": "7c69b9ca88e4f127f7280368f7055646",
+  "userMacAlgorithm": "sha256",
+  "userMacSecret": "5a25ad4feadd45fdcbb05402658272da",
+  "sessionSecret": "this is not a secret",
+  "useSSL": false,
+  "tokBox": {
+    "credentials": {
+      "default": {
+        "apiKey": "<put your apiKey here>",
+        "apiSecret": "<put your apiSecret here>"
+      }
     },
-    "webAppUrl": "http://localhost:3000/content/#call/{token}",
-    "sentryDSN": false,
-    "allowedOrigins": ["http://localhost:3000"],
-    "statsdEnabled": false,
-    "fxaAudiences": ["https://loop.services.mozilla.com",
-                     "app://loop.services.mozilla.com"]
+    "tokenDuration": 86400
+  },
+  "webAppUrl": "http://localhost:3000/content/#call/{token}",
+  "sentryDSN": false,
+  "allowedOrigins": [
+    "http://localhost:3000"
+  ],
+  "statsdEnabled": false,
+  "fxaAudiences": [
+    "https://loop.services.mozilla.com",
+    "app://loop.services.mozilla.com"
+  ]
 }

--- a/config/test.json
+++ b/config/test.json
@@ -35,13 +35,17 @@
     "token2": "T2==GcFydG5lcl9pZD00NDY4NzQ0MiZzZGtfdmVyc2lvbj10YnJ1YnktdGJyYi12MC45MS4yMDELxTyALT3EJnNpZz00ODkZNTQ1YTZlOWIzGOM2ZjmRMWFiYTdjZmFhNV2mOWUxMzFlMWYwOnJvbGU9cHVibGlzaGVyJnNlc3Npb25faWQ9M9VNWDQwTkRZNE56UTBNbjUtVjJWa0lFWMhjaUF4TWlBd016bzFPVG8xTVNCUVJGUWdNakF4Tkg0d0xqUTVPVE16TWpNM2ZnJmNyZWF0ZV90aW1lPTEzOTQ2MjE5OTcmbm9uY2U9MC4yMzM2MDQyMzM2MzY2OTQ1OCZleHBpcmVfdGltZT0xMzk0NjI1NTgzJmNvmb5lY3Rbp25fZGF0TY0=",
     "token3": "T3==GcFydG5lcl9pZD00NDY4NzQ0MiZzZGtfdmVyc2lvbj10YnJ1YnktdGJyYi12MC45MS4yMDELxTyALT3EJnNpZz00ODkZNTQ1YTZlOWIzGOM2ZjmRMWFiYTdjZmFhNV2mOWUxMzFlMWYwOnJvbGU9cHVibGlzaGVyJnNlc3Npb25faWQ9M9VNWDQwTkRZNE56UTBNbjUtVjJWa0lFWMhjaUF4TWlBd016bzFPVG8xTVNCUVJGUWdNakF4Tkg0d0xqUTVPVE16TWpNM2ZnJmNyZWF0ZV90aW1lPTEzOTQ2MjE5OTcmbm9uY2U9MC4yMzM2MDQyMzM2MzY2OTQ1OCZleHBpcmVfdGltZT0xMzk0NjI1NTgzJmNvmb5lY3Rbp25fZGF0TY0="
   },
-  "allowedOrigins": ["http://localhost:3000"],
+  "allowedOrigins": [
+    "http://localhost:3000"
+  ],
   "statsdEnabled": true,
-  "fxaAudiences": ["http://localhost:5000"],
+  "fxaAudiences": [
+    "http://localhost:5000"
+  ],
   "timers": {
-    "supervisoryDuration": 0.050,
-    "ringingDuration": 0.050,
-    "connectionDuration": 0.050
+    "supervisoryDuration": 0.05,
+    "ringingDuration": 0.05,
+    "connectionDuration": 0.05
   },
   "maxSimplePushUrls": 2
 }


### PR DESCRIPTION
Currently it doesn't look like we're linting the files in `loop/storage/*.js`, only `loop/*.js`.

Also, fixed the indenting in `config/sample.json` since it was inconsistent.
