### PR TITLE
adding a couple of npm scripts and tweaking travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ node_js:
 
 services: redis-server
 
+before_script:
+  - npm i nsp -g
+  - npm run outdated
+  - npm run audit-shrinkwrap
+
 script: make travis
 before_install:
   - "sudo apt-get install python-virtualenv"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
   },
   "scripts": {
     "test": "make test",
-    "start": "make runserver"
+    "start": "make runserver",
+    "outdated": "npm outdated --depth 0",
+    "audit-shrinkwrap": "npm shrinkwrap --dev && nsp audit-shrinkwrap || true"
   },
   "license": "MPL-2.0",
   "keywords": []


### PR DESCRIPTION
Added 2 new tasks:
1. `npm run outdated` &mdash; Looks for outdated npm modules in package.json. Informational only and won't fail any Travis builds. This also uses `--depth 0` so it only checks top-level modules, not pointless sub-sub-sub dependencies.
2. `npm run audit-shrinkwrap` &mdash; Uses [**nsp**](https://github.com/nodesecurity/nsp) to check a npm-shrinkwrap.json file for any known vuln modules in the https://nodesecurity.io database. This script will create a npm-shrinkwrap.json file and uses `|| true` to make sure the exit code is always 0 so it won't fail the Travis build.

**NOTE:** I'm installing **nsp** in the .travis.yml file, so if you want to run this locally, we'd need to:
a) install the **nsp** module globally using `npm i nsp -g`, or
b) install the **nsp** module locally as a devDep.

Because npm scripts don't need the `./node_modules/.bin/` junk, I think the package.json and .travis.yml wouldn't need to be altered either way.

I also tweaked the .travis.yml file to log out any known questionable modules using `npm run audit-shrinkwrap`.
