### PR TITLE
Bug 1047667 — Accept simplePushURL to be passed as querystring parameter.

### DIFF
--- a/test/functional_test.js
+++ b/test/functional_test.js
@@ -10,6 +10,7 @@ var supertest = addHawk(require("supertest"));
 var sinon = require("sinon");
 var randomBytes = require("crypto").randomBytes;
 var assert = sinon.assert;
+var querystring = require("querystring");
 
 var constants = require("../loop/constants");
 var loop = require("../loop");
@@ -702,6 +703,19 @@ function runOnPrefix(apiPrefix) {
       it("should remove an existing simple push url for an user", function(done) {
         register(url, expectedAssertion, hawkCredentials, function() {
           jsonReq.send({'simple_push_url': url})
+            .expect(204)
+            .end(done);
+        });
+      });
+
+      it("should remove a simple push url send in the query", function(done) {
+        register(url, expectedAssertion, hawkCredentials, function() {
+          supertest(app)
+            .del(apiPrefix + '/registration?' +
+                 querystring.stringify({simplePushURL: url}))
+            .hawk(hawkCredentials)
+            .type('json')
+            .send({})
             .expect(204)
             .end(done);
         });

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -4,6 +4,7 @@
 /* jshint expr: true */
 "use strict";
 
+var querystring = require("querystring");
 var expect = require("chai").expect;
 var randomBytes = require("crypto").randomBytes;
 var addHawk = require("superagent-hawk");
@@ -187,6 +188,26 @@ describe("index.js", function() {
         .end(done);
     });
 
+    it("should work with a valid simple push url in the querystring",
+      function(done) {
+        jsonReq
+          .post(apiPrefix + '/validateSP/?' + querystring.stringify({
+            simplePushURL: 'http://this-is-an-url'
+          }))
+          .send({})
+          .expect(200)
+          .end(done);
+      });
+
+    it("should accept simple_push_url when requesting simplePushURL.",
+      function(done) {
+        jsonReq
+          .post(apiPrefix + '/validateSP')
+          .send({simple_push_url: "http://deny"})
+          .expect(200)
+          .end(done);
+      });
+
   });
 
   describe("#validateCallType", function() {
@@ -258,15 +279,6 @@ describe("index.js", function() {
         .expect(406, /json/)
         .end(done);
     });
-
-    it("should accept simple_push_url when requesting simplePushURL.",
-      function(done) {
-        jsonReq
-          .post(apiPrefix + '/requireParams/simplePushURL')
-          .send({simple_push_url: "http://deny"})
-          .expect(200)
-          .end(done);
-      });
 
     it("should return a 400 if one of the required params are missing.",
       function(done) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1047667
