### PR TITLE
Bug 1099144 — Use redis hashes & sets for SP urls.

### DIFF
--- a/loop/storage/redis.js
+++ b/loop/storage/redis.js
@@ -95,11 +95,13 @@ RedisStorage.prototype = {
           function(err, simplePushMappings) {
             if (err) return callback(err);
             simplePushMappings.forEach(function(mapping) {
-              SIMPLE_PUSH_TOPICS.forEach(function(topic) {
-                if (output[topic].indexOf(mapping[topic]) === -1){
-                  output[topic].push(mapping[topic]);
-                }
-              });
+              if (mapping) {
+                SIMPLE_PUSH_TOPICS.forEach(function(topic) {
+                  if (mapping.hasOwnProperty(topic) && output[topic].indexOf(mapping[topic]) === -1) {
+                    output[topic].push(mapping[topic]);
+                  }
+                });
+              }
             });
             callback(null, output);
           });
@@ -187,7 +189,7 @@ RedisStorage.prototype = {
       'userUrls.' + userMac,
       'callurl.' + callUrlId,
       function(err, res) {
-        if (err){
+        if (err) {
           callback(err);
           return;
         }
@@ -445,7 +447,7 @@ RedisStorage.prototype = {
    **/
   getCallStateTTL: function(callId, callback) {
     this._client.pttl('callstate.' + callId, function(err, ttl) {
-      if (err){
+      if (err) {
         callback(err);
         return;
       }
@@ -600,7 +602,7 @@ RedisStorage.prototype = {
     var key = 'call.devices.' + callId + '.' + type;
 
     self._client.get(key, function(err, number) {
-      if (err){
+      if (err) {
         return callback(err);
       }
       return callback(err, parseInt(number));


### PR DESCRIPTION
Uses redis hashes and sets rather than normal keys and doing a keys with a "*"
in the lookup part. Doing so costs a lot to redis and it uses a lot of CPU to
compare the keys before returning the values.

Using hashes and sets reduces a lot the complexity of the calls (going from
O(Number of keys in the database) to O(Size of the hash) + O(Number of sessions
per user).

https://bugzilla.mozilla.org/show_bug.cgi?id=1099144
