### PR TITLE
Bug 1094998 — POST /rooms/:token action refresh without Authorization should 401.

### DIFF
--- a/test/rooms_test.js
+++ b/test/rooms_test.js
@@ -1185,6 +1185,20 @@ describe("/rooms", function() {
           clock.restore();
         });
 
+        it("should reject an unauthenticated user with a 401.",
+          function(done) {
+            createRoom(hawkCredentials).end(function(err, res) {
+              if (err) throw err;
+              var roomToken = res.body.roomToken;
+              supertest(app)
+                .post('/rooms/' + roomToken)
+                .send({action: "refresh"})
+                .type("json")
+                .expect(401)
+                .end(done);
+            });
+          });
+
         it("should touch the participant and return the next expiration.",
           function(done) {
             var startTime = parseInt(Date.now() / 1000, 10);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1094998
