### PR TITLE
Bug 1101774 — Add push to the __heartbeat__

### DIFF
--- a/loop/routes/home.js
+++ b/loop/routes/home.js
@@ -35,9 +35,11 @@ module.exports = function(app, conf, logError, storage, tokBox) {
     storage.ping(function(storageStatus) {
       tokBox.ping({timeout: conf.get('heartbeatTimeout')},
         function(requestError) {
+          // Setting pushStatus to undefined makes it not included in the json
+          // response.
           var pushStatus;
           if (req.query.SP_LOCATION !== undefined) {
-            request.get(req.query.SP_LOCATION, function(error, response) {
+            request.put(req.query.SP_LOCATION, function(error, response) {
               pushStatus = (!error && response.statusCode === 200);
               returnStatus(storageStatus, requestError, pushStatus);
             });

--- a/test/functional_test.js
+++ b/test/functional_test.js
@@ -305,7 +305,7 @@ function runOnPrefix(apiPrefix) {
           callback(null);
         });
 
-        sandbox.stub(request, "get", function(options, callback) {
+        sandbox.stub(request, "put", function(options, callback) {
           callback(new Error("error"));
         });
         supertest(app)
@@ -328,7 +328,7 @@ function runOnPrefix(apiPrefix) {
             callback(null);
           });
 
-          sandbox.stub(request, "get", function(options, callback) {
+          sandbox.stub(request, "put", function(options, callback) {
             callback(null, {statusCode: 200});
           });
           supertest(app)


### PR DESCRIPTION
If a SP_LOCATION querystring is provided, use it to check the connectivity of
the server with it.

https://bugzilla.mozilla.org/show_bug.cgi?id=1101774
