### PR TITLE
Bug 1069208 — Remove old 0.13 migration code.

### DIFF
--- a/loop/config.js
+++ b/loop/config.js
@@ -311,13 +311,6 @@ var conf = convict({
       default: 10
     }
   },
-  // XXX - Bug 1069208 — Remove this two month after 0.13 release
-  // (January 2015)
-  maxSimplePushUrls: {
-    doc: "The maximum number of simple-push urls stored for an user",
-    format: Number,
-    default: 10
-  },
   progressURLEndpoint: {
     doc: "The endpoint to use for the progressURL.",
     format: String,

--- a/test/storage_test.js
+++ b/test/storage_test.js
@@ -1101,20 +1101,6 @@ describe("Storage", function() {
       });
     });
 
-    // XXX - Bug 1069208 — Remove this two months after 0.13 release
-    // (January 2015)
-    it("should be able to retrieve old calls simplePushURLs", function(done) {
-      storage._client.lpush('spurl.' + userMac, "http://spurl.com", function(err) {
-        if (err) throw err;
-        storage.getUserSimplePushURLs(userMac, function(err, urls) {
-          if (err) throw err;
-          expect(urls.calls).to.length(1);
-          expect(urls.calls[0]).to.eql("http://spurl.com");
-          done();
-        });
-      });
-    });
-
     it("should handle storage errors correctly.", function(done) {
       sandbox.stub(storage._client, "smembers",
         function(key, callback){


### PR DESCRIPTION
I double checked, the 0.13 was released on November 6th and the 0.13.1 on November 13th then 0.13.2 on November 26th. So we can say that 0.13 branch was in production before November 26th and as we keep data for 1 month in the database all the migration would have been done before December 26th.

Here is the PR that remove the migration code.

https://bugzilla.mozilla.org/show_bug.cgi?id=1069208