### PR TITLE
Bug 1103331 — Get room public information if not participating

### DIFF
--- a/loop/routes/rooms.js
+++ b/loop/routes/rooms.js
@@ -294,7 +294,6 @@ module.exports = function (apiRouter, conf, logError, storage, auth,
       validators.isRoomParticipant(req, res, function() {
         getRoomInfo(req.token, req.roomStorageData, function(err, roomData) {
           if (res.serverError(err)) return;
-          delete roomData.roomToken;
           res.status(200).json(roomData);
         });
       });

--- a/test/rooms_test.js
+++ b/test/rooms_test.js
@@ -635,6 +635,7 @@ describe("/rooms", function() {
                 .replace('{token}', roomToken);
 
               expect(getRes.body).to.eql({
+                roomToken: roomToken,
                 roomUrl: roomUrl,
                 roomOwner: "Alexis",
                 roomName: "UX discussion",
@@ -767,12 +768,13 @@ describe("/rooms", function() {
                     .replace('{token}', roomToken);
 
                   expect(getRes.body).to.eql({
-                    "roomUrl": roomUrl,
-                    "clientMaxSize": 3,
-                    "maxSize": 3,
-                    "participants": [],
-                    "roomName": "New name",
-                    "roomOwner": "Alexis"
+                    roomToken: roomToken,
+                    roomUrl: roomUrl,
+                    clientMaxSize: 3,
+                    maxSize: 3,
+                    participants: [],
+                    roomName: "New name",
+                    roomOwner: "Alexis"
                   });
 
                   expect(requests).to.length(1);
@@ -838,12 +840,13 @@ describe("/rooms", function() {
                     .replace('{token}', roomToken);
 
                   expect(getRes.body).to.eql({
-                    "roomUrl": roomUrl,
-                    "clientMaxSize": 2,
-                    "maxSize": 2,
-                    "participants": [],
-                    "roomName": "About UX",
-                    "roomOwner": "Natim"
+                    roomToken: roomToken,
+                    roomUrl: roomUrl,
+                    clientMaxSize: 2,
+                    maxSize: 2,
+                    participants: [],
+                    roomName: "About UX",
+                    roomOwner: "Natim"
                   });
 
                   expect(requests).to.length(1);


### PR DESCRIPTION
Interpreted https://bugzilla.mozilla.org/show_bug.cgi?id=1103331 as I could.

I think it differs from what was proposed by @ametaireau, since I don't use the POST with `action == 'join'`
