### PR TITLE
Bug 1103898 — Websocket broadcast close only when needed.

### DIFF
--- a/loop/websockets.js
+++ b/loop/websockets.js
@@ -493,11 +493,18 @@ MessageHandler.prototype = {
             // Don't catch the errors here since we're already closing the
             // socket.
             if (connectedDevices === 1) {
-              self.broadcastState(
-                session,
-                constants.CALL_STATES.TERMINATED + ":" +
-                constants.MESSAGE_REASONS.CLOSED
-              );
+              // We want to broadcast the state only if there is no
+              // other terminate reason.
+              self.storage.getCallState(session.callId, function(err, state) {
+                if (err === null && state !== null &&
+                    state !== constants.CALL_STATES.TERMINATED) {
+                  self.broadcastState(
+                    session,
+                    constants.CALL_STATES.TERMINATED + ":" +
+                      constants.MESSAGE_REASONS.CLOSED
+                  );
+                }
+              });
             }
           });
         });

--- a/loop/websockets.js
+++ b/loop/websockets.js
@@ -494,7 +494,7 @@ MessageHandler.prototype = {
             // socket.
             if (connectedDevices === 1) {
               // We want to broadcast the state only if there is no
-              // other terminate reason.
+              // other TERMINATED reason.
               self.storage.getCallState(session.callId, function(err, state) {
                 if (err === null && state !== null &&
                     state !== constants.CALL_STATES.TERMINATED) {


### PR DESCRIPTION
There are already tests about receiving `terminate:close` when needed.

I am adding one about not receiving it when unneeded.

https://bugzilla.mozilla.org/show_bug.cgi?id=1103898