### PR TITLE
Bug 1140614 — Reproduce the Stale timestamp behavior in loadtest.

### DIFF
--- a/loadtests/loadtest/__init__.py
+++ b/loadtests/loadtest/__init__.py
@@ -36,6 +36,7 @@ class TestLoop(TestCallsMixin, TestRoomsMixin, TestWebsocketMixin, TestCase):
     def test_http_calls(self):
         self.setupCall()
         self.setupRoom()
+        self.test_401_with_stale_timestamp()
 
     def test_websockets(self):
         self._test_websockets_basic_scenario()


### PR DESCRIPTION
Needs this requests-hawk patch: https://github.com/mozilla-services/requests-hawk/pull/5/files