### PR TITLE
Fix venv rules for loadtests.

### DIFF
--- a/loadtests/Makefile
+++ b/loadtests/Makefile
@@ -23,7 +23,7 @@ install: ./venv/.env.install
 
 # Clean all the things installed by `make build`.
 clean:
-	rm -rf ./venv *.pyc
+	rm -rf ./venv loadtest/*.pyc
 
 # Run a single test from the venv machine, for sanity-checking.
 test: install

--- a/loadtests/Makefile
+++ b/loadtests/Makefile
@@ -9,7 +9,7 @@ INSTALL = ARCHFLAGS=$(ARCHFLAGS) ./venv/bin/pip install
 .PHONY: install clean bench megabench
 
 # Build virtualenv, to ensure we have all the dependencies.
-.env.install:
+./venv/.env.install:
 	virtualenv ./venv
 	$(INSTALL) pexpect >> loadtest.log && \
 	$(INSTALL) configparser==3.3.0post2 >> loadtest.log && \
@@ -17,14 +17,13 @@ INSTALL = ARCHFLAGS=$(ARCHFLAGS) ./venv/bin/pip install
 	$(INSTALL) git+git://github.com/mozilla-services/loads.git  >> loadtest.log && \
 	$(INSTALL) git+git://github.com/mozilla-services/requests-hawk.git >> loadtest.log && \
 	$(INSTALL) PyFxA[openssl] >> loadtest.log && \
-	rm loadtest.log || cat loadtest.log
-	touch $@
+	rm loadtest.log && touch $@ || cat loadtest.log
 
-install: .env.install
+install: ./venv/.env.install
 
 # Clean all the things installed by `make build`.
 clean:
-	rm -rf ./venv *.pyc .env.install
+	rm -rf ./venv *.pyc
 
 # Run a single test from the venv machine, for sanity-checking.
 test: install


### PR DESCRIPTION
When the installation was failling we were getting errors.
This PR files the following:

- [x] Doesn't create the .env.install file if the installation didn't worked
- [x] Recreate the venv if the venv dir was removed
