### PR TITLE
Use the PyFxA master rather than the (now merged) branch

### DIFF
--- a/loadtests/config/megabench.ini
+++ b/loadtests/config/megabench.ini
@@ -6,7 +6,7 @@ agents = 5
 detach = true
 observer = irc
 ssh = ubuntu@loads.services.mozilla.com
-python-dep = https://github.com/mozilla/PyFxA/archive/remove-entrypoints-dependency.zip
+python-dep = https://github.com/mozilla/PyFxA/archive/master.zip
              requests-hawk
              six
 no-dns-resolve = true

--- a/loadtests/config/megabench.ini
+++ b/loadtests/config/megabench.ini
@@ -6,7 +6,7 @@ agents = 5
 detach = true
 observer = irc
 ssh = ubuntu@loads.services.mozilla.com
-python-dep = https://github.com/mozilla/PyFxA/archive/master.zip
+python-dep = PyFxA
              requests-hawk
              six
 no-dns-resolve = true

--- a/loadtests/config/smoke.ini
+++ b/loadtests/config/smoke.ini
@@ -6,7 +6,7 @@ agents = 5
 detach = true
 observer = irc
 ssh = ubuntu@loads.services.mozilla.com
-python-dep = https://github.com/mozilla/PyFxA/archive/remove-entrypoints-dependency.zip
+python-dep = PyFxA
              requests-hawk
              six
 no-dns-resolve = true


### PR DESCRIPTION
cc @rpappalax r? @Natim 

This now uses the master branch. We might also use the released version if needed.