### PR TITLE
Implement a temporary proxy to Firebase

### DIFF
--- a/loop/index.js
+++ b/loop/index.js
@@ -135,6 +135,9 @@ var storeUserCallTokens = calls(apiRouter, conf, logError, storage, tokBox,
 var pushServerConfig = require("./routes/push-server-config");
 pushServerConfig(apiRouter, conf);
 
+var firebaseProxy = require("./routes/firebase-proxy");
+firebaseProxy(apiRouter, conf, logError, storage, auth, validators, statsdClient);
+
 if (conf.get("fxaOAuth").activated !== false) {
   var fxaOAuth = require("./routes/fxa-oauth");
   fxaOAuth(apiRouter, conf, logError, storage, auth, validators);

--- a/loop/routes/firebase-proxy.js
+++ b/loop/routes/firebase-proxy.js
@@ -1,0 +1,26 @@
+const httpProxy = require("http-proxy");
+const urlParse = require("url").parse;
+
+// XXX: this is temporary code, intended to be removed
+module.exports = function (apiRouter, conf, logError, storage, auth, validators, statsdClient) {
+  var proxy = httpProxy.createProxyServer({});
+  proxy.on("proxyRes", function (proxyRes, req, res) {
+    proxyRes.headers["access-control-allow-origin"] = "*";
+  });
+  apiRouter.all("/proxy",
+    function (req, res) {
+      var url = req.query.url;
+      var parsed = urlParse(url);
+      if (! parsed || ! parsed.host || parsed.protocol !== "https:") {
+        logError("Invalid proxy URL");
+        throw new Error("Invalid proxy URL: " + JSON.stringify(url) + " in " + JSON.stringify(parsed));
+      }
+      if (parsed.host.search(/\.firebaseio\.com$/) === -1) {
+        throw new Error("Proxy URL to somewhere other than firebaseio.com: " + JSON.stringify(parsed.host));
+      }
+      // Simple way to avoid invalid things like auth through the proxy:
+      var target = parsed.protocol + "//" + parsed.host + parsed.path;
+      proxy.web(req, res, {target: target, ignorePath: true, changeOrigin: true});
+    }
+  );
+};

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "heapdump": "0.3.5",
     "hiredis": "0.2.0",
     "hkdf": "0.0.2",
+    "http-proxy": "1.13.3",
     "mozlog": "1.0.2",
     "newrelic": "1.16.2",
     "node-uuid": "1.4.2",


### PR DESCRIPTION
This is a temporary workaround, to be deployed only on loop-demo

(Note currently master is deployed to loop-demo, but the server has to be updated to deploy the akita branch)

This implements a simple proxy that adds an Access-Control-Allow-Origin header to Firebase requests
