### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "phone": "git://github.com/Natim/node-phone.git#83a4f48",
     "raven": "0.7.2",
     "redis": "0.12.1",
-    "request": "2.45.0",
+    "request": "2.74.0",
     "sodium": "1.0.13",
     "node-statsd": "0.1.1",
     "strftime": "0.8.2",


### PR DESCRIPTION
loop-server currently has a 7 vulnerable dependency paths, introducing 6 different types of known vulnerabilities.

This PR fixes  vulnerable dependencies, [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/mozilla-services/loop-server) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix all the vulnerabilities listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade others dependencies as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)